### PR TITLE
🚨 Fix(#30): 채팅 안되는 현상 수정

### DIFF
--- a/src/main/kotlin/com/connect/service/chatting/controller/ChatWebSocketController.kt
+++ b/src/main/kotlin/com/connect/service/chatting/controller/ChatWebSocketController.kt
@@ -7,9 +7,11 @@ import org.springframework.messaging.handler.annotation.MessageMapping
 import org.springframework.messaging.handler.annotation.Payload
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor
 import org.springframework.messaging.simp.SimpMessagingTemplate
+import org.springframework.stereotype.Controller
 import org.springframework.web.bind.annotation.CrossOrigin
 import kotlin.collections.set
 
+@Controller
 @CrossOrigin
 class ChatWebSocketController (
     private val messagingTemplate: SimpMessagingTemplate,


### PR DESCRIPTION
원인 : 리팩토링하면서 분리한 Controller가 bean으로 등록되어 있지 않아서 messageMapping이 안되는 현상 발생 
내용 : WebSocket 메시징만을 담당하는 컨트롤러라면 @RestController보다는 @Controller가 더 의미론적으로 정확하고 적절하다. @RestController의 @ResponseBody 기능은 WebSocket 메시징에서는 필요 없는 부가 기능이기 때문이다. 