### PR TITLE
✨ Feat(#50): 카카오 소셜 로그인 추가

### DIFF
--- a/src/main/kotlin/com/connect/service/user/controller/KakaoAuthController.kt
+++ b/src/main/kotlin/com/connect/service/user/controller/KakaoAuthController.kt
@@ -1,0 +1,137 @@
+package com.connect.service.user.controller
+
+import com.connect.service.common.jwt.JwtTokenProvider
+import com.connect.service.common.jwt.dto.RefreshToken
+import com.connect.service.common.jwt.repository.RefreshTokenRepository
+import com.connect.service.user.service.KakaoOAuthService
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import mu.KotlinLogging
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.util.Base64
+
+@RestController
+@RequestMapping("/api/auth/kakao")
+class KakaoAuthController(
+    private val kakaoOAuthService: KakaoOAuthService,
+    private val jwtTokenProvider: JwtTokenProvider,
+    private val refreshTokenRepository: RefreshTokenRepository
+) {
+    companion object {
+        private val log = KotlinLogging.logger {}
+    }
+
+    @Value("\${spring.security.oauth2.client.registration.kakao.client-id}")
+    private lateinit var clientId: String
+
+    @Value("\${spring.security.oauth2.client.registration.kakao.redirect-uri}")
+    private lateinit var redirectUri: String
+
+    @Value("\${spring.security.oauth2.client.registration.kakao.scope}")
+    private lateinit var scope: String
+
+    @Value("\${spring.security.oauth2.client.provider.kakao.authorization-uri}")
+    private lateinit var authorizationUri: String
+
+    // 앱으로 돌려보낼 수 있는 리다이렉트 URI 화이트리스트 (오픈 리다이렉트 방지)
+    @Value("\${app.oauth2.allowed-redirect-uris}")
+    private lateinit var allowedRedirectUris: String
+
+    // 1단계: 프론트가 호출 → 카카오 인가 페이지로 302 리다이렉트
+    // redirectUri: 로그인 완료 후 토큰을 전달받을 앱의 주소(딥링크/웹 origin)
+    @GetMapping("/authorize")
+    fun authorize(
+        @RequestParam("redirectUri") appRedirectUri: String,
+        response: HttpServletResponse
+    ) {
+        if (!isAllowedRedirect(appRedirectUri)) {
+            log.warn("허용되지 않은 redirectUri 요청: {}", appRedirectUri)
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "허용되지 않은 redirectUri 입니다.")
+            return
+        }
+
+        // 앱의 최종 리다이렉트 주소를 state에 실어 카카오 왕복 후 콜백에서 복원
+        val state = Base64.getUrlEncoder().withoutPadding()
+            .encodeToString(appRedirectUri.toByteArray(StandardCharsets.UTF_8))
+
+        val kakaoAuthUrl = buildString {
+            append(authorizationUri)
+            append("?client_id=").append(clientId)
+            append("&redirect_uri=").append(encode(redirectUri))
+            append("&response_type=code")
+            append("&scope=").append(encode(scope))
+            append("&state=").append(state)
+        }
+
+        response.sendRedirect(kakaoAuthUrl)
+    }
+
+    // 2단계: 카카오가 인가 코드와 함께 호출하는 콜백
+    // 토큰 교환 → 사용자 조회/생성 → JWT 발급 → 앱 주소로 토큰 리다이렉트
+    @GetMapping("/callback")
+    fun callback(
+        @RequestParam("code") code: String,
+        @RequestParam("state") state: String,
+        request: HttpServletRequest,
+        response: HttpServletResponse
+    ) {
+        val appRedirectUri = try {
+            String(Base64.getUrlDecoder().decode(state), StandardCharsets.UTF_8)
+        } catch (e: Exception) {
+            log.warn("state 디코딩 실패: {}", state)
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "잘못된 state 입니다.")
+            return
+        }
+
+        if (!isAllowedRedirect(appRedirectUri)) {
+            log.warn("허용되지 않은 redirectUri 콜백: {}", appRedirectUri)
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "허용되지 않은 redirectUri 입니다.")
+            return
+        }
+
+        // 카카오 토큰 교환 및 사용자 정보 조회
+        val kakaoAccessToken = kakaoOAuthService.exchangeCodeForToken(code)
+        val kakaoUser = kakaoOAuthService.fetchKakaoUser(kakaoAccessToken)
+        val user = kakaoOAuthService.loginOrRegister(kakaoUser)
+
+        // 우리 서비스의 JWT(Access/Refresh) 발급 (일반 로그인과 동일한 흐름)
+        val authentication = UsernamePasswordAuthenticationToken(user, null, user.authorities)
+        val accessToken = jwtTokenProvider.createAccessToken(authentication)
+        val (refreshTokenString, refreshTokenExpiresAt) = jwtTokenProvider.createRefreshToken(authentication)
+
+        val newRefreshTokenEntity = RefreshToken(
+            userId = user.userId,
+            token = refreshTokenString,
+            issuedAt = LocalDateTime.now(),
+            expiresAt = refreshTokenExpiresAt.toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime(),
+            ipAddress = request.remoteAddr,
+            userAgent = request.getHeader("User-Agent")
+        )
+        refreshTokenRepository.save(newRefreshTokenEntity)
+
+        // 앱 주소로 토큰 전달 (쿼리 파라미터)
+        val separator = if (appRedirectUri.contains("?")) "&" else "?"
+        val targetUrl = "$appRedirectUri${separator}accessToken=${encode(accessToken)}&refreshToken=${encode(refreshTokenString)}"
+        response.sendRedirect(targetUrl)
+    }
+
+    // 화이트리스트에 등록된 접두사로 시작하는지 검증
+    private fun isAllowedRedirect(uri: String): Boolean {
+        return allowedRedirectUris.split(",")
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+            .any { uri.startsWith(it) }
+    }
+
+    private fun encode(value: String): String =
+        URLEncoder.encode(value, StandardCharsets.UTF_8)
+}

--- a/src/main/kotlin/com/connect/service/user/dto/KakaoUserInfo.kt
+++ b/src/main/kotlin/com/connect/service/user/dto/KakaoUserInfo.kt
@@ -1,0 +1,9 @@
+package com.connect.service.user.dto
+
+// 카카오 사용자 정보 응답에서 우리 서비스가 사용하는 값만 추린 DTO
+data class KakaoUserInfo(
+    val id: String, // 카카오 회원번호 (고유 식별자)
+    val email: String?, // 카카오 계정 이메일 (동의 안 했으면 null)
+    val nickname: String?, // 카카오 프로필 닉네임
+    val profileImage: String? // 카카오 프로필 이미지 URL
+)

--- a/src/main/kotlin/com/connect/service/user/service/KakaoOAuthService.kt
+++ b/src/main/kotlin/com/connect/service/user/service/KakaoOAuthService.kt
@@ -1,0 +1,119 @@
+package com.connect.service.user.service
+
+import com.connect.service.user.domain.Users
+import com.connect.service.user.dto.KakaoUserInfo
+import com.connect.service.user.repository.UserRepository
+import mu.KotlinLogging
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpMethod
+import org.springframework.http.MediaType
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.util.LinkedMultiValueMap
+import org.springframework.web.client.RestTemplate
+import java.util.UUID
+
+@Service
+class KakaoOAuthService(
+    private val userRepository: UserRepository,
+    private val passwordEncoder: PasswordEncoder
+) {
+    companion object {
+        private val log = KotlinLogging.logger {}
+    }
+
+    @Value("\${spring.security.oauth2.client.registration.kakao.client-id}")
+    private lateinit var clientId: String
+
+    @Value("\${spring.security.oauth2.client.registration.kakao.client-secret}")
+    private lateinit var clientSecret: String
+
+    @Value("\${spring.security.oauth2.client.registration.kakao.redirect-uri}")
+    private lateinit var redirectUri: String
+
+    @Value("\${spring.security.oauth2.client.provider.kakao.token-uri}")
+    private lateinit var tokenUri: String
+
+    @Value("\${spring.security.oauth2.client.provider.kakao.user-info-uri}")
+    private lateinit var userInfoUri: String
+
+    private val restTemplate = RestTemplate()
+
+    // 인가 코드(code)를 카카오 액세스 토큰으로 교환
+    fun exchangeCodeForToken(code: String): String {
+        val headers = HttpHeaders().apply {
+            contentType = MediaType.APPLICATION_FORM_URLENCODED
+        }
+        val body = LinkedMultiValueMap<String, String>().apply {
+            add("grant_type", "authorization_code")
+            add("client_id", clientId)
+            add("client_secret", clientSecret)
+            add("redirect_uri", redirectUri)
+            add("code", code)
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        val response = restTemplate.postForObject(
+            tokenUri,
+            HttpEntity(body, headers),
+            Map::class.java
+        ) as? Map<String, Any> ?: throw IllegalStateException("카카오 토큰 응답이 비어 있습니다.")
+
+        return response["access_token"] as? String
+            ?: throw IllegalStateException("카카오 액세스 토큰을 찾을 수 없습니다.")
+    }
+
+    // 카카오 액세스 토큰으로 사용자 정보 조회
+    fun fetchKakaoUser(kakaoAccessToken: String): KakaoUserInfo {
+        val headers = HttpHeaders().apply {
+            setBearerAuth(kakaoAccessToken)
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        val response = restTemplate.exchange(
+            userInfoUri,
+            HttpMethod.GET,
+            HttpEntity<Void>(headers),
+            Map::class.java
+        ).body as? Map<String, Any> ?: throw IllegalStateException("카카오 사용자 정보 응답이 비어 있습니다.")
+
+        val id = response["id"]?.toString()
+            ?: throw IllegalStateException("카카오 회원번호를 찾을 수 없습니다.")
+
+        val account = response["kakao_account"] as? Map<*, *>
+        val profile = account?.get("profile") as? Map<*, *>
+
+        return KakaoUserInfo(
+            id = id,
+            email = account?.get("email") as? String,
+            nickname = profile?.get("nickname") as? String,
+            profileImage = profile?.get("profile_image_url") as? String
+        )
+    }
+
+    // 카카오 사용자를 우리 서비스 사용자(Users)로 연결. 없으면 신규 생성
+    @Transactional
+    fun loginOrRegister(info: KakaoUserInfo): Users {
+        // 소셜 사용자는 별도 스키마 변경 없이 userId 접두사("kakao_")로 식별
+        val userId = "kakao_${info.id}"
+
+        userRepository.findByUserId(userId)?.let {
+            log.info("기존 카카오 사용자 로그인: userId = {}", userId)
+            return it
+        }
+
+        val newUser = Users(
+            userId = userId,
+            email = info.email ?: "$userId@kakao.local", // 이메일 미동의 시 대체 이메일 사용
+            name = info.nickname ?: "카카오사용자",
+            // 소셜 로그인은 비밀번호가 없으므로 임의의 난수를 암호화하여 저장(비밀번호 로그인 차단 효과)
+            rawPassword = passwordEncoder.encode(UUID.randomUUID().toString()),
+            profileUrl = info.profileImage
+        )
+        log.info("신규 카카오 사용자 생성: userId = {}", userId)
+        return userRepository.save(newUser)
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,7 +16,7 @@ ip2location.api.key=${IP2LOCATION_API_KEY}
 # KAKAO
 spring.security.oauth2.client.registration.kakao.client-id=${KAKAO_CLIENT_ID}
 spring.security.oauth2.client.registration.kakao.client-secret=${KAKAO_CLIENT_SECRET}
-spring.security.oauth2.client.registration.kakao.redirect-uri=http://localhost:8100/login/oauth2/code/kakao
+spring.security.oauth2.client.registration.kakao.redirect-uri=${KAKAO_REDIRECT_URI:http://localhost:8889/api/auth/kakao/callback}
 spring.security.oauth2.client.registration.kakao.authorization-grant-type=authorization_code
 spring.security.oauth2.client.registration.kakao.scope=profile_nickname,profile_image,account_email
 spring.security.oauth2.client.registration.kakao.client-name=Kakao
@@ -24,6 +24,9 @@ spring.security.oauth2.client.provider.kakao.authorization-uri=https://kauth.kak
 spring.security.oauth2.client.provider.kakao.token-uri=https://kauth.kakao.com/oauth/token
 spring.security.oauth2.client.provider.kakao.user-info-uri=https://kapi.kakao.com/v2/user/me
 spring.security.oauth2.client.provider.kakao.user-name-attribute=id
+
+# 카카오 로그인 완료 후 토큰을 돌려보낼 수 있는 앱 리다이렉트 URI 화이트리스트 (오픈 리다이렉트 방지)
+app.oauth2.allowed-redirect-uris=${APP_OAUTH2_ALLOWED_REDIRECT_URIS:exp://,exps://,connect://,http://localhost,http://127.0.0.1}
 
 spring.mail.host=smtp.gmail.com
 spring.mail.port=587

--- a/src/test/kotlin/com/connect/service/user/KakaoOAuthServiceTest.kt
+++ b/src/test/kotlin/com/connect/service/user/KakaoOAuthServiceTest.kt
@@ -1,0 +1,91 @@
+package com.connect.service.user
+
+import com.connect.service.user.domain.Users
+import com.connect.service.user.dto.KakaoUserInfo
+import com.connect.service.user.repository.UserRepository
+import com.connect.service.user.service.KakaoOAuthService
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@ExtendWith(MockitoExtension::class)
+class KakaoOAuthServiceTest {
+
+    @Mock
+    private lateinit var userRepository: UserRepository
+
+    @Mock
+    private lateinit var passwordEncoder: org.springframework.security.crypto.password.PasswordEncoder
+
+    @InjectMocks
+    private lateinit var kakaoOAuthService: KakaoOAuthService
+
+    @Test
+    @DisplayName("신규 카카오 사용자는 kakao_ 접두사 userId로 새로 생성된다")
+    fun `신규_카카오_사용자_생성`() {
+        // Given: 해당 카카오 사용자가 아직 없음
+        val info = KakaoUserInfo(id = "123456", email = "user@kakao.com", nickname = "홍길동", profileImage = "http://img/p.jpg")
+        whenever(userRepository.findByUserId("kakao_123456")).thenReturn(null)
+        whenever(passwordEncoder.encode(any())).thenReturn("encoded-random")
+        // save는 전달받은 엔티티를 그대로 반환하도록 설정
+        whenever(userRepository.save(any<Users>())).thenAnswer { it.arguments[0] as Users }
+
+        // When
+        val result = kakaoOAuthService.loginOrRegister(info)
+
+        // Then
+        assertEquals("kakao_123456", result.userId)
+        assertEquals("user@kakao.com", result.email)
+        assertEquals("홍길동", result.name)
+        assertEquals("http://img/p.jpg", result.profileUrl)
+        verify(userRepository).save(any<Users>())
+    }
+
+    @Test
+    @DisplayName("이메일/닉네임 미동의 시 대체 값으로 사용자를 생성한다")
+    fun `이메일_닉네임_없을때_대체값_생성`() {
+        // Given: 이메일과 닉네임이 모두 null
+        val info = KakaoUserInfo(id = "999", email = null, nickname = null, profileImage = null)
+        whenever(userRepository.findByUserId("kakao_999")).thenReturn(null)
+        whenever(passwordEncoder.encode(any())).thenReturn("encoded-random")
+        whenever(userRepository.save(any<Users>())).thenAnswer { it.arguments[0] as Users }
+
+        // When
+        val result = kakaoOAuthService.loginOrRegister(info)
+
+        // Then: 대체 이메일/닉네임이 채워진다
+        assertEquals("kakao_999", result.userId)
+        assertTrue(result.email.endsWith("@kakao.local"))
+        assertEquals("카카오사용자", result.name)
+    }
+
+    @Test
+    @DisplayName("기존 카카오 사용자는 새로 생성하지 않고 재사용한다")
+    fun `기존_카카오_사용자_재사용`() {
+        // Given: 동일한 카카오 사용자가 이미 존재
+        val existing = Users(
+            userId = "kakao_123456",
+            email = "user@kakao.com",
+            name = "홍길동",
+            rawPassword = "stored"
+        )
+        whenever(userRepository.findByUserId("kakao_123456")).thenReturn(existing)
+        val info = KakaoUserInfo(id = "123456", email = "user@kakao.com", nickname = "홍길동", profileImage = null)
+
+        // When
+        val result = kakaoOAuthService.loginOrRegister(info)
+
+        // Then: 기존 사용자를 그대로 반환하고 저장은 호출하지 않는다
+        assertEquals(existing, result)
+        verify(userRepository, never()).save(any<Users>())
+    }
+}


### PR DESCRIPTION
## 작업 내용
카카오 소셜 로그인(OAuth2 인가코드 흐름)을 백엔드에 추가했습니다.

### 추가/변경
- `GET /api/auth/kakao/authorize` → 카카오 인가 페이지로 리다이렉트 (state 로 앱 redirectUri 전달)
- `GET /api/auth/kakao/callback` → 토큰 교환 → 사용자 조회/생성 → JWT 발급 후 앱으로 토큰 리다이렉트
- `KakaoOAuthService`: 카카오 토큰 교환/사용자 조회, `userId=\"kakao_{id}\"` 규칙으로 DB 스키마 변경 없이 소셜 사용자 식별
- 오픈 리다이렉트 방지용 `app.oauth2.allowed-redirect-uris` 화이트리스트
- `KakaoOAuthService` 단위 테스트 3건 추가 (통과)

### 설정 필요 (카카오 디벨로퍼 콘솔)
- Redirect URI 에 `http://localhost:8889/api/auth/kakao/callback` 등록
- 프론트는 connect-ui 저장소의 `feature/kakao-login` 브랜치 참고

관련 이슈: #50