### PR TITLE
✨ Feat(#127): 더존 이메일 인증 + 모집 글 작성자 인증 마크

### DIFF
--- a/src/main/kotlin/com/connect/service/board/controller/BoardController.kt
+++ b/src/main/kotlin/com/connect/service/board/controller/BoardController.kt
@@ -52,10 +52,10 @@ class BoardController(private val boardService: BoardService) {
     }
 
     @GetMapping("/{id}")
-    fun getBoardDetail(@PathVariable id: Long): ResponseEntity<BoardMst> {
-        return boardService.getBoardById(id)
-            .map { board -> ResponseEntity.ok(board) }
-            .orElse(ResponseEntity.notFound().build())
+    fun getBoardDetail(@PathVariable id: Long): ResponseEntity<com.connect.service.board.dto.BoardResponseDto> {
+        val detail = boardService.getBoardDetail(id)
+            ?: return ResponseEntity.notFound().build()
+        return ResponseEntity.ok(detail)
     }
 
     @PreAuthorize("isAuthenticated()")

--- a/src/main/kotlin/com/connect/service/board/dto/BoardResponseDto.kt
+++ b/src/main/kotlin/com/connect/service/board/dto/BoardResponseDto.kt
@@ -15,11 +15,12 @@ data class BoardResponseDto(
     val deadlineDts: LocalDateTime, // 마감일 (LocalDateTime -> String 변환은 나중에 수행)
     val destination: String, // 목적지
     val maxCapacity: Int, // 최대 모집 인원
-    val currentParticipants: Int // 모집 인원
+    val currentParticipants: Int, // 모집 인원
+    val verified: Boolean = false // 작성자의 더존 이메일 인증 여부 (인증 마크 표시용)
 ) {
     // BoardMst 엔티티를 BoardResponseDto로 변환하는 팩토리 메서드
     companion object {
-        fun from(boardMst: BoardMst): BoardResponseDto {
+        fun from(boardMst: BoardMst, verified: Boolean = false): BoardResponseDto {
             return BoardResponseDto(
                 id = boardMst.id ?: throw IllegalArgumentException("Board ID cannot be null"), // id는 null이 아님을 가정
                 title = boardMst.title,
@@ -32,7 +33,8 @@ data class BoardResponseDto(
                 deadlineDts = boardMst.deadlineDts,
                 destination = boardMst.destination,
                 maxCapacity = boardMst.maxCapacity,
-                currentParticipants = boardMst.currentParticipants
+                currentParticipants = boardMst.currentParticipants,
+                verified = verified
             )
         }
     }

--- a/src/main/kotlin/com/connect/service/board/service/BoardService.kt
+++ b/src/main/kotlin/com/connect/service/board/service/BoardService.kt
@@ -5,6 +5,8 @@ import com.connect.service.board.dto.BoardResponseDto
 import com.connect.service.board.dto.PaginatedBoardResponse
 import com.connect.service.board.entity.BoardMst
 import com.connect.service.board.repository.BoardRepository
+import com.connect.service.user.domain.UserRole
+import com.connect.service.user.repository.UserRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.Optional
@@ -14,14 +16,30 @@ import org.springframework.http.HttpStatus
 import org.springframework.web.server.ResponseStatusException
 
 @Service
-class BoardService(private val boardRepository: BoardRepository) {
+class BoardService(
+    private val boardRepository: BoardRepository,
+    private val userRepository: UserRepository
+) {
+
+    // 주어진 작성자 ID들 중 더존 이메일 인증(ROLE_VERIFIED)된 사용자 ID 집합을 반환
+    private fun verifiedUserIds(userIds: Collection<String>): Set<String> {
+        val distinct = userIds.distinct()
+        if (distinct.isEmpty()) {
+            return emptySet()
+        }
+        return userRepository.findByUserIdIn(distinct)
+            .filter { it.roles.contains(UserRole.ROLE_VERIFIED) }
+            .map { it.userId }
+            .toSet()
+    }
 
     @Transactional(readOnly = true)
     fun getAllBoards(pageable: Pageable): PaginatedBoardResponse {
         val boardPage: Page<BoardMst> = boardRepository.findAllByIsDeletedFalse(pageable)
 
+        val verified = verifiedUserIds(boardPage.content.map { it.userId })
         val boardResponseDtos: List<BoardResponseDto> = boardPage.content
-            .map { BoardResponseDto.from(it) } // 각 BoardMst 엔티티를 DTO로 변환
+            .map { BoardResponseDto.from(it, verified.contains(it.userId)) }
 
         // 다음 페이지가 있다면 다음 페이지 번호를, 없으면 null 반환
         val nextPageToken: Int? = if (boardPage.hasNext()) {
@@ -41,8 +59,9 @@ class BoardService(private val boardRepository: BoardRepository) {
     fun getBoardsByAuthor(userId: String, pageable: Pageable): PaginatedBoardResponse {
         val boardPage: Page<BoardMst> = boardRepository.findAllByUserIdAndIsDeletedFalse(userId, pageable)
 
+        val verified = verifiedUserIds(boardPage.content.map { it.userId })
         val boardResponseDtos: List<BoardResponseDto> = boardPage.content
-            .map { BoardResponseDto.from(it) }
+            .map { BoardResponseDto.from(it, verified.contains(it.userId)) }
 
         val nextPageToken: Int? = if (boardPage.hasNext()) {
             boardPage.number + 1
@@ -54,6 +73,14 @@ class BoardService(private val boardRepository: BoardRepository) {
             nextPageToken = nextPageToken,
             posts = boardResponseDtos
         )
+    }
+
+    // 게시글 상세 (작성자 인증 여부 verified 포함)
+    @Transactional(readOnly = true)
+    fun getBoardDetail(id: Long): BoardResponseDto? {
+        val board = boardRepository.findById(id).orElse(null) ?: return null
+        val verified = verifiedUserIds(listOf(board.userId)).contains(board.userId)
+        return BoardResponseDto.from(board, verified)
     }
 
     @Transactional

--- a/src/main/kotlin/com/connect/service/user/controller/AccountController.kt
+++ b/src/main/kotlin/com/connect/service/user/controller/AccountController.kt
@@ -1,6 +1,7 @@
 package com.connect.service.user.controller
 
 import com.connect.service.common.ApiResponse
+import com.connect.service.user.domain.UserRole
 import com.connect.service.user.dto.EmailRequest
 import com.connect.service.user.dto.ResetPasswordRequest
 import com.connect.service.user.dto.UpdateNameRequest
@@ -93,8 +94,54 @@ class AccountController (
         }
         return try {
             val updated = accountService.updateUserName(authentication.name, request.name)
-            val info = UserInfoResponse(updated.userId, updated.email, updated.name, updated.profileUrl)
+            val info = UserInfoResponse(
+                updated.userId, updated.email, updated.name, updated.profileUrl,
+                updated.roles.contains(UserRole.ROLE_VERIFIED)
+            )
             ResponseEntity.ok(ApiResponse.success("이름이 변경되었습니다.", info))
+        } catch (e: IllegalArgumentException) {
+            ResponseEntity.badRequest().body(ApiResponse.error(e.message ?: "잘못된 요청입니다."))
+        }
+    }
+
+    /**
+     * 더존 이메일 인증번호 발송 (@douzone.com 만 허용)
+     * POST /api/account/verify-douzone/send-code
+     */
+    @PostMapping("/verify-douzone/send-code")
+    fun sendDouzoneCode(@RequestBody request: EmailRequest): ResponseEntity<ApiResponse<Unit>> {
+        return try {
+            accountService.sendDouzoneVerificationCode(request.email)
+            ResponseEntity.ok(ApiResponse.success("인증번호가 이메일로 발송되었습니다."))
+        } catch (e: IllegalArgumentException) {
+            ResponseEntity.badRequest().body(ApiResponse.error(e.message ?: "잘못된 요청입니다."))
+        } catch (e: Exception) {
+            ResponseEntity.internalServerError().body(ApiResponse.error("인증번호 발송에 실패했습니다. 잠시 후 다시 시도해주세요."))
+        }
+    }
+
+    /**
+     * 더존 이메일 인증 확정 (성공 시 ROLE_VERIFIED 부여)
+     * POST /api/account/verify-douzone/confirm
+     */
+    @PostMapping("/verify-douzone/confirm")
+    fun confirmDouzone(
+        @RequestBody request: VerificationRequest,
+        authentication: Authentication?
+    ): ResponseEntity<ApiResponse<UserInfoResponse>> {
+        if (authentication == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(ApiResponse.error("로그인이 필요합니다."))
+        }
+        return try {
+            val updated = accountService.verifyDouzoneEmail(authentication.name, request.email, request.code)
+                ?: return ResponseEntity.badRequest()
+                    .body(ApiResponse.error("인증번호가 일치하지 않거나 만료되었습니다."))
+            val info = UserInfoResponse(
+                updated.userId, updated.email, updated.name, updated.profileUrl,
+                updated.roles.contains(UserRole.ROLE_VERIFIED)
+            )
+            ResponseEntity.ok(ApiResponse.success("더존 이메일 인증이 완료되었습니다.", info))
         } catch (e: IllegalArgumentException) {
             ResponseEntity.badRequest().body(ApiResponse.error(e.message ?: "잘못된 요청입니다."))
         }

--- a/src/main/kotlin/com/connect/service/user/controller/AuthController.kt
+++ b/src/main/kotlin/com/connect/service/user/controller/AuthController.kt
@@ -170,7 +170,8 @@ class AuthController(
                 userId = customUserDetails.getUserId(),
                 email = customUserDetails.getEmail(),
                 name = customUserDetails.getName(),
-                profileUrl = customUserDetails.getProfileUrl()
+                profileUrl = customUserDetails.getProfileUrl(),
+                verified = customUserDetails.isVerified()
             )
 
             log.info("사용자 정보 조회 성공: userId = {}", customUserDetails.getUserId())

--- a/src/main/kotlin/com/connect/service/user/domain/CustomUserDetails.kt
+++ b/src/main/kotlin/com/connect/service/user/domain/CustomUserDetails.kt
@@ -29,4 +29,6 @@ class CustomUserDetails(
     fun getEmail(): String = user.email
     fun getName(): String = user.name
     fun getProfileUrl(): String? = user.profileUrl
+    // 더존 이메일 인증 완료 여부 (ROLE_VERIFIED 보유 시 true)
+    fun isVerified(): Boolean = user.roles?.contains(UserRole.ROLE_VERIFIED) ?: false
 }

--- a/src/main/kotlin/com/connect/service/user/domain/UserRole.kt
+++ b/src/main/kotlin/com/connect/service/user/domain/UserRole.kt
@@ -2,5 +2,6 @@ package com.connect.service.user.domain
 
 enum class UserRole {
     ROLE_USER,
-    ROLE_ADMIN
+    ROLE_ADMIN,
+    ROLE_VERIFIED // 더존 이메일 인증 완료 사용자 (인증 마크 표시)
 }

--- a/src/main/kotlin/com/connect/service/user/dto/UserInfoResponse.kt
+++ b/src/main/kotlin/com/connect/service/user/dto/UserInfoResponse.kt
@@ -4,5 +4,6 @@ data class UserInfoResponse(
     val userId: String,
     val email: String,
     val name: String,
-    val profileUrl: String? = null // 프로필 URL은 없을 수도 있으므로 nullable
+    val profileUrl: String? = null, // 프로필 URL은 없을 수도 있으므로 nullable
+    val verified: Boolean = false // 더존 이메일 인증 완료 여부
 )

--- a/src/main/kotlin/com/connect/service/user/service/AccountService.kt
+++ b/src/main/kotlin/com/connect/service/user/service/AccountService.kt
@@ -2,6 +2,7 @@ package com.connect.service.user.service
 
 import com.connect.service.board.repository.BoardRepository
 import com.connect.service.user.domain.EmailVerification
+import com.connect.service.user.domain.UserRole
 import com.connect.service.user.domain.Users
 import com.connect.service.user.dto.VerificationInfo
 import com.connect.service.user.repository.EmailVerificationRepository
@@ -30,6 +31,7 @@ class AccountService(
             "^[a-zA-Z0-9_!#$%&'*+/=?`{|}~^.-]+@[a-zA-Z0-9.-]+\$"
         )
     private val VERIFICATION_CODE_EXPIRY_MINUTES: Long = 5 // 인증번호 유효 시간 5분
+    private val DOUZONE_EMAIL_DOMAIN = "@douzone.com" // 인증 가능한 사내 이메일 도메인
 
     @Transactional
     fun sendVerificationCode(email: String): Boolean {
@@ -113,6 +115,58 @@ class AccountService(
         println("'$email' 사용자의 비밀번호가 성공적으로 재설정되었습니다.")
         return true
 
+    }
+
+    /**
+     * 더존 이메일(@douzone.com) 인증번호 발송.
+     * 비밀번호 찾기와 달리 가입된 이메일일 필요는 없지만, 반드시 @douzone.com 도메인이어야 합니다.
+     */
+    @Transactional
+    fun sendDouzoneVerificationCode(email: String): Boolean {
+        if (!isValidEmail(email)) {
+            throw IllegalArgumentException("유효하지 않은 이메일 주소입니다.")
+        }
+        if (!email.lowercase().endsWith(DOUZONE_EMAIL_DOMAIN)) {
+            throw IllegalArgumentException("@douzone.com 이메일만 인증할 수 있습니다.")
+        }
+
+        // 기존 미사용 인증코드 무효화
+        val existingVerifications = emailVerificationRepository
+            .findAllByEmailAndExpiresAtAfterAndIsUsedFalse(email, LocalDateTime.now())
+        existingVerifications.forEach { it.isUsed = true }
+        emailVerificationRepository.saveAll(existingVerifications)
+
+        val verificationCode = generateRandomNumber(6)
+        val expiryTime = LocalDateTime.now().plusMinutes(VERIFICATION_CODE_EXPIRY_MINUTES)
+        emailVerificationRepository.save(
+            EmailVerification(email = email, verificationCode = verificationCode, expiresAt = expiryTime)
+        )
+
+        val message = SimpleMailMessage()
+        message.setTo(email)
+        message.setSubject("[같이타] 더존 이메일 인증번호")
+        message.setText("안녕하세요.\n\n[같이타] 더존 이메일 인증번호는 [ $verificationCode ] 입니다.\n\n이 인증번호는 $VERIFICATION_CODE_EXPIRY_MINUTES 분 후 만료됩니다.")
+        javaMailSender.send(message)
+
+        return true
+    }
+
+    /**
+     * 더존 이메일 인증 확정. 인증번호가 유효하면 해당 사용자에게 ROLE_VERIFIED 를 부여합니다.
+     * @return 인증 성공 시 갱신된 사용자, 인증번호 불일치/만료 시 null
+     */
+    @Transactional
+    fun verifyDouzoneEmail(userId: String, email: String, code: String): Users? {
+        if (!email.lowercase().endsWith(DOUZONE_EMAIL_DOMAIN)) {
+            throw IllegalArgumentException("@douzone.com 이메일만 인증할 수 있습니다.")
+        }
+        if (!verifyCode(email, code)) {
+            return null
+        }
+        val user = userRepository.findByUserId(userId)
+            ?: throw IllegalArgumentException("사용자를 찾을 수 없습니다.")
+        user.roles.add(UserRole.ROLE_VERIFIED)
+        return userRepository.save(user)
     }
 
     /**

--- a/src/test/kotlin/com/connect/service/board/BoardAuthorServiceTest.kt
+++ b/src/test/kotlin/com/connect/service/board/BoardAuthorServiceTest.kt
@@ -3,6 +3,7 @@ package com.connect.service.board
 import com.connect.service.board.entity.BoardMst
 import com.connect.service.board.repository.BoardRepository
 import com.connect.service.board.service.BoardService
+import com.connect.service.user.repository.UserRepository
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -24,6 +25,9 @@ class BoardAuthorServiceTest {
 
     @Mock
     private lateinit var boardRepository: BoardRepository
+
+    @Mock
+    private lateinit var userRepository: UserRepository
 
     @InjectMocks
     private lateinit var boardService: BoardService
@@ -49,6 +53,7 @@ class BoardAuthorServiceTest {
         val boards = listOf(sampleBoard(1, "kakao_1"), sampleBoard(2, "kakao_1"))
         whenever(boardRepository.findAllByUserIdAndIsDeletedFalse(eq("kakao_1"), any()))
             .thenReturn(PageImpl(boards, pageable, boards.size.toLong()))
+        whenever(userRepository.findByUserIdIn(any())).thenReturn(emptyList())
 
         // When
         val result = boardService.getBoardsByAuthor("kakao_1", pageable)

--- a/src/test/kotlin/com/connect/service/board/BoardControllerTest.kt
+++ b/src/test/kotlin/com/connect/service/board/BoardControllerTest.kt
@@ -54,8 +54,8 @@ class BoardControllerTest {
         // given: 테스트를 위한 mock 데이터 설정
         val boardId = 999L // 존재하지 않는 ID
 
-        // when: boardService.getBoardById(boardId) 호출 시 Optional.empty() 반환하도록 Mocking
-        `when`(boardService.getBoardById(boardId)).thenReturn(Optional.empty())
+        // when: boardService.getBoardDetail(boardId) 호출 시 null 반환하도록 Mocking
+        `when`(boardService.getBoardDetail(boardId)).thenReturn(null)
 
         // then: MockMvc를 사용하여 HTTP GET 요청을 보내고 결과를 검증
         mockMvc.perform(
@@ -64,31 +64,32 @@ class BoardControllerTest {
         )
             .andExpect(status().isNotFound) // HTTP 상태 코드가 404 Not Found인지 검증
 
-        // verify: boardService.getBoardById(boardId) 메서드가 1번 호출되었는지 검증
-        verify(boardService, times(1)).getBoardById(boardId)
+        // verify: boardService.getBoardDetail(boardId) 메서드가 1번 호출되었는지 검증
+        verify(boardService, times(1)).getBoardDetail(boardId)
     }
 
     @Test
     fun `getBoardDetail - 게시글이 존재할 경우 200 OK와 게시글 반환`() {
         // given: 테스트를 위한 mock 데이터 설정
         val boardId = 1L
-        val expectedBoard = BoardMst(
+        val expectedBoard = BoardResponseDto(
             id = boardId,
             title = "새로운 제목",
             content = "더욱 풍성한 내용입니다.",
             category = "운동",
+            commentCount = 3,
             userId = "100",
             userName = "김테스트",
+            insertDts = LocalDateTime.now(),
             deadlineDts = LocalDateTime.of(2026, 1, 31, 23, 59),
             destination = "한강공원",
             maxCapacity = 5,
             currentParticipants = 2,
-            commentCount = 3,
-            isDeleted = false
+            verified = true
         )
 
-        // when: boardService.getBoardById(boardId) 호출 시 Optional.of(expectedBoard) 반환하도록 Mocking
-        `when`(boardService.getBoardById(boardId)).thenReturn(Optional.of(expectedBoard))
+        // when: boardService.getBoardDetail(boardId) 호출 시 DTO 반환하도록 Mocking
+        `when`(boardService.getBoardDetail(boardId)).thenReturn(expectedBoard)
 
         // then: MockMvc를 사용하여 HTTP GET 요청을 보내고 결과를 검증
         mockMvc.perform(
@@ -99,9 +100,10 @@ class BoardControllerTest {
             .andExpect(jsonPath("$.id").value(expectedBoard.id)) // 응답 본문의 id 필드 검증
             .andExpect(jsonPath("$.title").value(expectedBoard.title)) // 응답 본문의 title 필드 검증
             .andExpect(jsonPath("$.content").value(expectedBoard.content)) // 응답 본문의 content 필드 검증
+            .andExpect(jsonPath("$.verified").value(true)) // 작성자 인증 여부 검증
 
-        // verify: boardService.getBoardById(boardId) 메서드가 1번 호출되었는지 검증
-        verify(boardService, times(1)).getBoardById(boardId)
+        // verify: boardService.getBoardDetail(boardId) 메서드가 1번 호출되었는지 검증
+        verify(boardService, times(1)).getBoardDetail(boardId)
     }
 
     @Test

--- a/src/test/kotlin/com/connect/service/user/AccountServiceTest.kt
+++ b/src/test/kotlin/com/connect/service/user/AccountServiceTest.kt
@@ -1,6 +1,8 @@
 package com.connect.service.user
 
 import com.connect.service.board.repository.BoardRepository
+import com.connect.service.user.domain.EmailVerification
+import com.connect.service.user.domain.UserRole
 import com.connect.service.user.domain.Users
 import com.connect.service.user.repository.EmailVerificationRepository
 import com.connect.service.user.repository.UserRepository
@@ -13,12 +15,17 @@ import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.mail.javamail.JavaMailSender
 import org.springframework.security.crypto.password.PasswordEncoder
+import java.time.LocalDateTime
+import java.util.Optional
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 @ExtendWith(MockitoExtension::class)
 class AccountServiceTest {
@@ -79,5 +86,64 @@ class AccountServiceTest {
         assertThrows<IllegalArgumentException> {
             accountService.updateUserName("nope", "이름")
         }
+    }
+
+    @Test
+    @DisplayName("@douzone.com 이 아닌 이메일은 인증번호 발송이 거부된다")
+    fun `더존_도메인_아니면_발송_예외`() {
+        assertThrows<IllegalArgumentException> {
+            accountService.sendDouzoneVerificationCode("user@gmail.com")
+        }
+        // 도메인 검증에서 막히므로 메일 발송/저장은 호출되지 않음
+        verify(emailVerificationRepository, never()).save(any<EmailVerification>())
+    }
+
+    @Test
+    @DisplayName("더존 이메일 인증 성공 시 ROLE_VERIFIED 가 부여된다")
+    fun `더존_인증_성공_ROLE_VERIFIED_부여`() {
+        // Given: 유효한 인증번호가 존재
+        val email = "hong@douzone.com"
+        val code = "123456"
+        val verification = EmailVerification(
+            email = email,
+            verificationCode = code,
+            expiresAt = LocalDateTime.now().plusMinutes(5)
+        )
+        whenever(
+            emailVerificationRepository.findByEmailAndVerificationCodeAndExpiresAtAfterAndIsUsedFalse(
+                eq(email), eq(code), any()
+            )
+        ).thenReturn(Optional.of(verification))
+        whenever(emailVerificationRepository.save(any<EmailVerification>())).thenAnswer { it.arguments[0] }
+
+        val user = Users(userId = "kakao_1", email = "kakao_1@kakao.local", name = "홍길동", rawPassword = "x")
+        whenever(userRepository.findByUserId("kakao_1")).thenReturn(user)
+        whenever(userRepository.save(any<Users>())).thenAnswer { it.arguments[0] as Users }
+
+        // When
+        val result = accountService.verifyDouzoneEmail("kakao_1", email, code)
+
+        // Then: ROLE_VERIFIED 부여
+        assertNotNull(result)
+        assertTrue(result.roles.contains(UserRole.ROLE_VERIFIED))
+    }
+
+    @Test
+    @DisplayName("인증번호가 틀리면 null 을 반환하고 ROLE_VERIFIED 를 부여하지 않는다")
+    fun `더존_인증_실패_null`() {
+        // Given: 일치하는 인증코드 없음
+        val email = "hong@douzone.com"
+        whenever(
+            emailVerificationRepository.findByEmailAndVerificationCodeAndExpiresAtAfterAndIsUsedFalse(
+                eq(email), eq("000000"), any()
+            )
+        ).thenReturn(Optional.empty())
+
+        // When
+        val result = accountService.verifyDouzoneEmail("kakao_1", email, "000000")
+
+        // Then
+        assertEquals(null, result)
+        verify(userRepository, never()).save(any<Users>())
     }
 }


### PR DESCRIPTION
## 작업 내용
더존 이메일(@douzone.com) 인증과 모집 글 작성자 인증 마크 기능입니다. (#50 카카오/마이페이지 작업에서 분리)

### 추가/변경
- `POST /api/account/verify-douzone/send-code` / `/confirm` — @douzone.com 이메일 인증
- 인증 성공 시 `ROLE_VERIFIED` 부여 — **기존 user_roles 테이블 재사용으로 DB 스키마 변경 없음**
- `UserInfoResponse` / `BoardResponseDto` 에 `verified` 추가, 게시글 목록/상세에 작성자 인증여부 포함
- `getBoardDetail` 이 `BoardResponseDto`(verified 포함) 반환
- AccountService(더존 인증)/Board 테스트 추가·갱신 (통과)

### 참고
- 이 기능은 마이페이지 작업과 같은 파일을 공유하여 **base 를 `feature/kakao-login-50` 로 설정**(스택). #126 머지 후 base 를 dev 로 변경하면 됩니다.
- 프론트: connect-ui `feature/verified-mark` 브랜치

Closes #127