### PR TITLE
✨ Feat: 특정 날짜 이메일 알림 기능

### DIFF
--- a/src/main/kotlin/com/connect/service/ConnectApplication.kt
+++ b/src/main/kotlin/com/connect/service/ConnectApplication.kt
@@ -2,8 +2,10 @@ package com.connect.service
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.scheduling.annotation.EnableScheduling
 
 @SpringBootApplication
+@EnableScheduling // 날짜 알림 이메일 발송 스케줄러 활성화
 class ConnectApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/com/connect/service/reminder/controller/ReminderController.kt
+++ b/src/main/kotlin/com/connect/service/reminder/controller/ReminderController.kt
@@ -1,0 +1,56 @@
+package com.connect.service.reminder.controller
+
+import com.connect.service.reminder.dto.ReminderCreateRequest
+import com.connect.service.reminder.dto.ReminderResponse
+import com.connect.service.reminder.service.ReminderService
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.Authentication
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api/account/reminders") // /api/account/** 는 SecurityConfig 에서 허용되므로 별도 설정 불필요
+@CrossOrigin
+class ReminderController(
+    private val reminderService: ReminderService
+) {
+    // 알림 등록
+    @PostMapping
+    fun create(
+        @RequestBody request: ReminderCreateRequest,
+        authentication: Authentication?
+    ): ResponseEntity<Any> {
+        if (authentication == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("로그인이 필요합니다.")
+        }
+        return try {
+            val saved = reminderService.create(authentication.name, request)
+            ResponseEntity.ok(ReminderResponse.from(saved))
+        } catch (e: IllegalArgumentException) {
+            ResponseEntity.badRequest().body(e.message ?: "잘못된 요청입니다.")
+        }
+    }
+
+    // 내 알림 목록
+    @GetMapping
+    fun list(authentication: Authentication?): ResponseEntity<List<ReminderResponse>> {
+        if (authentication == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build()
+        }
+        val reminders = reminderService.list(authentication.name).map { ReminderResponse.from(it) }
+        return ResponseEntity.ok(reminders)
+    }
+
+    // 알림 삭제
+    @DeleteMapping("/{id}")
+    fun delete(
+        @PathVariable id: Long,
+        authentication: Authentication?
+    ): ResponseEntity<Any> {
+        if (authentication == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("로그인이 필요합니다.")
+        }
+        reminderService.delete(authentication.name, id)
+        return ResponseEntity.noContent().build()
+    }
+}

--- a/src/main/kotlin/com/connect/service/reminder/dto/ReminderDto.kt
+++ b/src/main/kotlin/com/connect/service/reminder/dto/ReminderDto.kt
@@ -1,0 +1,31 @@
+package com.connect.service.reminder.dto
+
+import com.connect.service.reminder.entity.DateReminder
+import java.time.LocalDate
+
+// 알림 등록 요청. email 미지정 시 계정 이메일로 발송.
+data class ReminderCreateRequest(
+    val reminderDate: LocalDate, // "2026-09-12" 형식 (ISO)
+    val content: String,
+    val email: String? = null
+)
+
+data class ReminderResponse(
+    val id: Long,
+    val reminderDate: LocalDate,
+    val content: String,
+    val email: String,
+    val notified: Boolean
+) {
+    companion object {
+        fun from(r: DateReminder): ReminderResponse {
+            return ReminderResponse(
+                id = r.id ?: throw IllegalArgumentException("Reminder ID cannot be null"),
+                reminderDate = r.reminderDate,
+                content = r.content,
+                email = r.email,
+                notified = r.notified
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/connect/service/reminder/entity/DateReminder.kt
+++ b/src/main/kotlin/com/connect/service/reminder/entity/DateReminder.kt
@@ -1,0 +1,37 @@
+package com.connect.service.reminder.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+// 특정 날짜 알림. 해당 날짜가 되면 이메일로 알림을 발송한다.
+@Entity
+@Table(name = "date_reminder")
+data class DateReminder(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+
+    @Column(name = "user_id", nullable = false)
+    val userId: String, // 알림을 등록한 사용자
+
+    @Column(nullable = false)
+    val email: String, // 알림을 받을 이메일
+
+    @Column(name = "reminder_date", nullable = false)
+    val reminderDate: LocalDate, // 알림 날짜 (예: 2026-09-12)
+
+    @Column(nullable = false)
+    val content: String, // 알림 내용 (예: 오전 반차)
+
+    @Column(nullable = false)
+    var notified: Boolean = false, // 발송 완료 여부 (중복 발송 방지)
+
+    @Column(name = "created_at", nullable = false)
+    val createdAt: LocalDateTime = LocalDateTime.now()
+)

--- a/src/main/kotlin/com/connect/service/reminder/repository/ReminderRepository.kt
+++ b/src/main/kotlin/com/connect/service/reminder/repository/ReminderRepository.kt
@@ -1,0 +1,15 @@
+package com.connect.service.reminder.repository
+
+import com.connect.service.reminder.entity.DateReminder
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.time.LocalDate
+
+@Repository
+interface ReminderRepository : JpaRepository<DateReminder, Long> {
+    // 마이페이지: 내 알림 목록 (날짜 오름차순)
+    fun findByUserIdOrderByReminderDateAsc(userId: String): List<DateReminder>
+
+    // 스케줄러: 해당 날짜에 아직 발송하지 않은 알림
+    fun findByReminderDateAndNotifiedFalse(reminderDate: LocalDate): List<DateReminder>
+}

--- a/src/main/kotlin/com/connect/service/reminder/scheduler/ReminderScheduler.kt
+++ b/src/main/kotlin/com/connect/service/reminder/scheduler/ReminderScheduler.kt
@@ -1,0 +1,26 @@
+package com.connect.service.reminder.scheduler
+
+import com.connect.service.reminder.service.ReminderService
+import mu.KotlinLogging
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import java.time.LocalDate
+
+@Component
+class ReminderScheduler(
+    private val reminderService: ReminderService
+) {
+    companion object {
+        private val log = KotlinLogging.logger {}
+    }
+
+    // 매일 오전 9시에 당일 알림을 이메일로 발송
+    @Scheduled(cron = "0 0 9 * * *")
+    fun sendTodayReminders() {
+        val today = LocalDate.now()
+        val sent = reminderService.sendDueReminders(today)
+        if (sent > 0) {
+            log.info("일정 알림 이메일 발송 완료: {}건 (날짜={})", sent, today)
+        }
+    }
+}

--- a/src/main/kotlin/com/connect/service/reminder/service/ReminderService.kt
+++ b/src/main/kotlin/com/connect/service/reminder/service/ReminderService.kt
@@ -1,0 +1,80 @@
+package com.connect.service.reminder.service
+
+import com.connect.service.reminder.dto.ReminderCreateRequest
+import com.connect.service.reminder.entity.DateReminder
+import com.connect.service.reminder.repository.ReminderRepository
+import com.connect.service.user.repository.UserRepository
+import mu.KotlinLogging
+import org.springframework.http.HttpStatus
+import org.springframework.mail.SimpleMailMessage
+import org.springframework.mail.javamail.JavaMailSender
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.server.ResponseStatusException
+import java.time.LocalDate
+
+@Service
+class ReminderService(
+    private val reminderRepository: ReminderRepository,
+    private val userRepository: UserRepository,
+    private val javaMailSender: JavaMailSender
+) {
+    companion object {
+        private val log = KotlinLogging.logger {}
+    }
+
+    // 알림 등록. email 미지정 시 계정 이메일 사용.
+    @Transactional
+    fun create(userId: String, request: ReminderCreateRequest): DateReminder {
+        if (request.content.isBlank()) {
+            throw IllegalArgumentException("알림 내용을 입력해주세요.")
+        }
+        val user = userRepository.findByUserId(userId)
+            ?: throw IllegalArgumentException("사용자를 찾을 수 없습니다.")
+        val email = request.email?.trim()?.takeIf { it.isNotEmpty() } ?: user.email
+
+        val reminder = DateReminder(
+            userId = userId,
+            email = email,
+            reminderDate = request.reminderDate,
+            content = request.content.trim()
+        )
+        return reminderRepository.save(reminder)
+    }
+
+    @Transactional(readOnly = true)
+    fun list(userId: String): List<DateReminder> {
+        return reminderRepository.findByUserIdOrderByReminderDateAsc(userId)
+    }
+
+    @Transactional
+    fun delete(userId: String, id: Long) {
+        val reminder = reminderRepository.findById(id)
+            .orElseThrow { ResponseStatusException(HttpStatus.NOT_FOUND, "알림을 찾을 수 없습니다.") }
+        if (reminder.userId != userId) {
+            throw ResponseStatusException(HttpStatus.FORBIDDEN, "본인 알림만 삭제할 수 있습니다.")
+        }
+        reminderRepository.delete(reminder)
+    }
+
+    // 해당 날짜의 미발송 알림을 이메일로 발송하고 발송 완료로 표시. (스케줄러에서 호출)
+    @Transactional
+    fun sendDueReminders(today: LocalDate): Int {
+        val dueList = reminderRepository.findByReminderDateAndNotifiedFalse(today)
+        dueList.forEach { reminder ->
+            try {
+                val message = SimpleMailMessage()
+                message.setTo(reminder.email)
+                message.setSubject("[같이타] 일정 알림")
+                message.setText("오늘(${reminder.reminderDate}) 일정 알림입니다.\n\n- ${reminder.content}")
+                javaMailSender.send(message)
+                reminder.notified = true
+            } catch (e: Exception) {
+                // 한 건 실패가 전체를 막지 않도록 로깅 후 계속 (notified 는 false 유지 → 다음 회차 재시도)
+                log.error("알림 이메일 발송 실패: id=${reminder.id}, email=${reminder.email}, 이유=${e.message}")
+            }
+        }
+        reminderRepository.saveAll(dueList)
+        return dueList.count { it.notified }
+    }
+}

--- a/src/test/kotlin/com/connect/service/reminder/ReminderServiceTest.kt
+++ b/src/test/kotlin/com/connect/service/reminder/ReminderServiceTest.kt
@@ -1,0 +1,94 @@
+package com.connect.service.reminder
+
+import com.connect.service.reminder.dto.ReminderCreateRequest
+import com.connect.service.reminder.entity.DateReminder
+import com.connect.service.reminder.repository.ReminderRepository
+import com.connect.service.reminder.service.ReminderService
+import com.connect.service.user.domain.Users
+import com.connect.service.user.repository.UserRepository
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.mail.SimpleMailMessage
+import org.springframework.mail.javamail.JavaMailSender
+import java.time.LocalDate
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@ExtendWith(MockitoExtension::class)
+class ReminderServiceTest {
+
+    @Mock
+    private lateinit var reminderRepository: ReminderRepository
+
+    @Mock
+    private lateinit var userRepository: UserRepository
+
+    @Mock
+    private lateinit var javaMailSender: JavaMailSender
+
+    @InjectMocks
+    private lateinit var reminderService: ReminderService
+
+    @Test
+    @DisplayName("이메일 미지정 시 계정 이메일로 알림을 등록한다")
+    fun `이메일_미지정시_계정이메일_사용`() {
+        val user = Users(userId = "u1", email = "me@douzone.com", name = "홍길동", rawPassword = "x")
+        whenever(userRepository.findByUserId("u1")).thenReturn(user)
+        whenever(reminderRepository.save(any<DateReminder>())).thenAnswer { it.arguments[0] as DateReminder }
+
+        val req = ReminderCreateRequest(LocalDate.of(2026, 9, 12), "오전 반차", null)
+        val result = reminderService.create("u1", req)
+
+        assertEquals("me@douzone.com", result.email)
+        assertEquals("오전 반차", result.content)
+        assertEquals(LocalDate.of(2026, 9, 12), result.reminderDate)
+    }
+
+    @Test
+    @DisplayName("이메일을 지정하면 해당 이메일로 등록한다")
+    fun `이메일_지정시_해당_이메일_사용`() {
+        val user = Users(userId = "u1", email = "me@douzone.com", name = "홍길동", rawPassword = "x")
+        whenever(userRepository.findByUserId("u1")).thenReturn(user)
+        whenever(reminderRepository.save(any<DateReminder>())).thenAnswer { it.arguments[0] as DateReminder }
+
+        val req = ReminderCreateRequest(LocalDate.of(2026, 9, 13), "오후 반차", "custom@douzone.com")
+        val result = reminderService.create("u1", req)
+
+        assertEquals("custom@douzone.com", result.email)
+    }
+
+    @Test
+    @DisplayName("알림 내용이 비어 있으면 예외를 던진다")
+    fun `빈_내용_예외`() {
+        assertThrows<IllegalArgumentException> {
+            reminderService.create("u1", ReminderCreateRequest(LocalDate.of(2026, 9, 12), "   ", null))
+        }
+        verify(reminderRepository, never()).save(any<DateReminder>())
+    }
+
+    @Test
+    @DisplayName("당일 미발송 알림을 이메일로 보내고 발송 완료로 표시한다")
+    fun `당일_알림_발송_및_표시`() {
+        val today = LocalDate.of(2026, 9, 12)
+        val reminder = DateReminder(
+            id = 1L, userId = "u1", email = "a@douzone.com",
+            reminderDate = today, content = "오전 반차", notified = false
+        )
+        whenever(reminderRepository.findByReminderDateAndNotifiedFalse(today)).thenReturn(listOf(reminder))
+
+        val sent = reminderService.sendDueReminders(today)
+
+        verify(javaMailSender).send(any<SimpleMailMessage>())
+        assertTrue(reminder.notified)
+        assertEquals(1, sent)
+    }
+}


### PR DESCRIPTION
## 작업 내용
특정 날짜에 이메일 알림을 보내는 기능입니다. (마이페이지에서 날짜 설정)

### 추가
- `DateReminder` 엔티티 + `/api/account/reminders` CRUD (POST/GET/DELETE, JWT 사용자 기준)
- `@EnableScheduling` + 매일 오전 9시 스케줄러 → 당일 알림 이메일 발송 후 발송완료 표시
- email 미지정 시 계정 이메일로 발송
- ReminderService 단위 테스트 (통과)

### ⚠️ DB 마이그레이션 필요 (ddl-auto=none 이라 수동 생성)
```sql
CREATE TABLE date_reminder (
  id BIGINT NOT NULL AUTO_INCREMENT,
  user_id VARCHAR(255) NOT NULL,
  email VARCHAR(255) NOT NULL,
  reminder_date DATE NOT NULL,
  content VARCHAR(255) NOT NULL,
  notified BIT(1) NOT NULL DEFAULT b'0',
  created_at DATETIME NOT NULL,
  PRIMARY KEY (id)
);
```
- 프론트: connect-ui `feature/date-reminder`

Closes #132