### PR TITLE
🐛 Fix: /api/account/** CORS preflight 차단 수정

### DIFF
--- a/src/main/kotlin/com/connect/service/common/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/connect/service/common/security/SecurityConfig.kt
@@ -43,6 +43,8 @@ class SecurityConfig(
                     .requestMatchers("/api/auth/**").permitAll() // 로그인, 회원가입 등 인증 관련 경로는 모두 허용
                     .requestMatchers("/api/public/**").permitAll() // 공개 API 경로
                     .requestMatchers("/api/boards/**").permitAll() // 게시판 API 경로
+                    // 비밀번호 찾기/더존 인증/날짜 알림 등 계정 관련 경로 허용 (CORS preflight 통과 + 컨트롤러에서 자체 인증 검사)
+                    .requestMatchers("/api/account/**").permitAll()
                     .anyRequest().authenticated() // 그 외 모든 요청은 인증 필요
             }
             .headers { headers ->


### PR DESCRIPTION
## 수정 내용
웹(localhost:8082)에서 `/api/account/**` 엔드포인트 호출 시 CORS preflight(OPTIONS)가 Spring Security 의 `anyRequest().authenticated()` 에 막혀 "Failed to fetch" 발생하던 문제 수정.

- `/api/account/**` 를 permitAll 로 추가 → preflight 통과 (각 컨트롤러는 JWT 자체 인증 검사 유지)
- 날짜 알림(`/api/account/reminders`) 웹 호출 가능
- 기존 비밀번호 찾기(`/api/account/find-password`)도 동일 원인으로 웹에서 깨져 있던 것 함께 해결