### PR TITLE
✨ Feat: 알림 발송 이메일을 인증한 이메일로 고정

### DIFF
--- a/src/main/kotlin/com/connect/service/reminder/service/ReminderService.kt
+++ b/src/main/kotlin/com/connect/service/reminder/service/ReminderService.kt
@@ -16,7 +16,8 @@ class ReminderService(
     private val userRepository: UserRepository
 ) {
 
-    // 알림 등록. email 미지정 시 계정 이메일 사용. 등록은 누구나 가능(이메일 발송만 인증 사용자 한정 - 배치에서 처리)
+    // 알림 등록. 발송 대상 이메일은 항상 계정(인증) 이메일을 사용 - 별도 입력 받지 않음.
+    // 등록은 누구나 가능(이메일 발송만 인증 사용자 한정 - 배치에서 처리)
     @Transactional
     fun create(userId: String, request: ReminderCreateRequest): DateReminder {
         if (request.content.isBlank()) {
@@ -24,11 +25,10 @@ class ReminderService(
         }
         val user = userRepository.findByUserId(userId)
             ?: throw IllegalArgumentException("사용자를 찾을 수 없습니다.")
-        val email = request.email?.trim()?.takeIf { it.isNotEmpty() } ?: user.email
 
         val reminder = DateReminder(
             userId = userId,
-            email = email,
+            email = user.email, // 계정(인증) 이메일로 발송
             reminderDate = request.reminderDate,
             content = request.content.trim()
         )

--- a/src/main/kotlin/com/connect/service/user/domain/Users.kt
+++ b/src/main/kotlin/com/connect/service/user/domain/Users.kt
@@ -16,7 +16,7 @@ data class Users(
     val userId: String, // 로그인 시 사용될 사용자 ID
 
     @Column(nullable = false)
-    val email: String, // 더존 이메일
+    var email: String, // 이메일 (더존 이메일 인증 시 인증한 주소로 갱신 - 알림 발송 대상)
 
     @Column(nullable = false)
     var name: String, // 사용자 별칭 (마이페이지에서 수정 가능)

--- a/src/main/kotlin/com/connect/service/user/service/AccountService.kt
+++ b/src/main/kotlin/com/connect/service/user/service/AccountService.kt
@@ -166,6 +166,8 @@ class AccountService(
         val user = userRepository.findByUserId(userId)
             ?: throw IllegalArgumentException("사용자를 찾을 수 없습니다.")
         user.roles.add(UserRole.ROLE_VERIFIED)
+        // 인증한 이메일을 계정 이메일로 저장 (이후 알림 등 발송은 이 주소로)
+        user.email = email
         return userRepository.save(user)
     }
 

--- a/src/test/kotlin/com/connect/service/reminder/ReminderServiceTest.kt
+++ b/src/test/kotlin/com/connect/service/reminder/ReminderServiceTest.kt
@@ -48,16 +48,17 @@ class ReminderServiceTest {
     }
 
     @Test
-    @DisplayName("이메일을 지정하면 해당 이메일로 등록한다")
-    fun `이메일_지정시_해당_이메일_사용`() {
+    @DisplayName("요청에 이메일을 넣어도 무시하고 항상 계정(인증) 이메일을 사용한다")
+    fun `요청_이메일_무시하고_계정이메일_사용`() {
         val user = Users(userId = "u1", email = "me@douzone.com", name = "홍길동", rawPassword = "x")
         whenever(userRepository.findByUserId("u1")).thenReturn(user)
         whenever(reminderRepository.save(any<DateReminder>())).thenAnswer { it.arguments[0] as DateReminder }
 
+        // 요청에 다른 이메일을 넣어도 계정 이메일로 등록되어야 함
         val req = ReminderCreateRequest(LocalDate.of(2026, 9, 13), "오후 반차", "custom@douzone.com")
         val result = reminderService.create("u1", req)
 
-        assertEquals("custom@douzone.com", result.email)
+        assertEquals("me@douzone.com", result.email)
     }
 
     @Test

--- a/src/test/kotlin/com/connect/service/user/AccountServiceTest.kt
+++ b/src/test/kotlin/com/connect/service/user/AccountServiceTest.kt
@@ -123,9 +123,10 @@ class AccountServiceTest {
         // When
         val result = accountService.verifyDouzoneEmail("kakao_1", email, code)
 
-        // Then: ROLE_VERIFIED 부여
+        // Then: ROLE_VERIFIED 부여 + 계정 이메일이 인증 이메일로 갱신
         assertNotNull(result)
         assertTrue(result.roles.contains(UserRole.ROLE_VERIFIED))
+        assertEquals(email, result.email)
     }
 
     @Test


### PR DESCRIPTION
더존 이메일 인증 시 계정 이메일을 인증 주소로 갱신하고, 알림 생성 시 별도 입력 없이 항상 계정(인증) 이메일로 발송하도록 변경.