### PR TITLE
✨ Feat: 알림 기능을 더존 이메일 인증 사용자 전용으로 제한

### DIFF
--- a/src/main/kotlin/com/connect/service/reminder/service/ReminderService.kt
+++ b/src/main/kotlin/com/connect/service/reminder/service/ReminderService.kt
@@ -3,6 +3,7 @@ package com.connect.service.reminder.service
 import com.connect.service.reminder.dto.ReminderCreateRequest
 import com.connect.service.reminder.entity.DateReminder
 import com.connect.service.reminder.repository.ReminderRepository
+import com.connect.service.user.domain.UserRole
 import com.connect.service.user.repository.UserRepository
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
@@ -16,8 +17,7 @@ class ReminderService(
     private val userRepository: UserRepository
 ) {
 
-    // 알림 등록. 발송 대상 이메일은 항상 계정(인증) 이메일을 사용 - 별도 입력 받지 않음.
-    // 등록은 누구나 가능(이메일 발송만 인증 사용자 한정 - 배치에서 처리)
+    // 알림 등록. 더존 이메일 인증 사용자만 가능하며, 발송 대상은 계정(인증) 이메일을 사용(별도 입력 없음).
     @Transactional
     fun create(userId: String, request: ReminderCreateRequest): DateReminder {
         if (request.content.isBlank()) {
@@ -25,6 +25,10 @@ class ReminderService(
         }
         val user = userRepository.findByUserId(userId)
             ?: throw IllegalArgumentException("사용자를 찾을 수 없습니다.")
+        // 더존 이메일 인증(ROLE_VERIFIED) 사용자만 알림 기능 사용 가능
+        if (!user.roles.contains(UserRole.ROLE_VERIFIED)) {
+            throw IllegalArgumentException("더존 이메일 인증 후 이용할 수 있습니다.")
+        }
 
         val reminder = DateReminder(
             userId = userId,

--- a/src/test/kotlin/com/connect/service/reminder/ReminderServiceTest.kt
+++ b/src/test/kotlin/com/connect/service/reminder/ReminderServiceTest.kt
@@ -4,6 +4,7 @@ import com.connect.service.reminder.dto.ReminderCreateRequest
 import com.connect.service.reminder.entity.DateReminder
 import com.connect.service.reminder.repository.ReminderRepository
 import com.connect.service.reminder.service.ReminderService
+import com.connect.service.user.domain.UserRole
 import com.connect.service.user.domain.Users
 import com.connect.service.user.repository.UserRepository
 import org.junit.jupiter.api.DisplayName
@@ -35,7 +36,10 @@ class ReminderServiceTest {
     @Test
     @DisplayName("이메일 미지정 시 계정 이메일로 알림을 등록한다 (등록은 누구나 가능)")
     fun `이메일_미지정시_계정이메일_사용`() {
-        val user = Users(userId = "u1", email = "me@douzone.com", name = "홍길동", rawPassword = "x")
+        val user = Users(
+            userId = "u1", email = "me@douzone.com", name = "홍길동", rawPassword = "x",
+            roles = mutableSetOf(UserRole.ROLE_USER, UserRole.ROLE_VERIFIED)
+        )
         whenever(userRepository.findByUserId("u1")).thenReturn(user)
         whenever(reminderRepository.save(any<DateReminder>())).thenAnswer { it.arguments[0] as DateReminder }
 
@@ -50,7 +54,10 @@ class ReminderServiceTest {
     @Test
     @DisplayName("요청에 이메일을 넣어도 무시하고 항상 계정(인증) 이메일을 사용한다")
     fun `요청_이메일_무시하고_계정이메일_사용`() {
-        val user = Users(userId = "u1", email = "me@douzone.com", name = "홍길동", rawPassword = "x")
+        val user = Users(
+            userId = "u1", email = "me@douzone.com", name = "홍길동", rawPassword = "x",
+            roles = mutableSetOf(UserRole.ROLE_USER, UserRole.ROLE_VERIFIED)
+        )
         whenever(userRepository.findByUserId("u1")).thenReturn(user)
         whenever(reminderRepository.save(any<DateReminder>())).thenAnswer { it.arguments[0] as DateReminder }
 
@@ -66,6 +73,20 @@ class ReminderServiceTest {
     fun `빈_내용_예외`() {
         assertThrows<IllegalArgumentException> {
             reminderService.create("u1", ReminderCreateRequest(LocalDate.of(2026, 9, 12), "   ", null))
+        }
+        verify(reminderRepository, never()).save(any<DateReminder>())
+    }
+
+    @Test
+    @DisplayName("더존 이메일 인증(ROLE_VERIFIED)이 없으면 알림 등록을 거부한다")
+    fun `미인증_사용자_거부`() {
+        // Given: ROLE_VERIFIED 없는 일반 사용자
+        val user = Users(userId = "u1", email = "u1@kakao.local", name = "미인증", rawPassword = "x")
+        whenever(userRepository.findByUserId("u1")).thenReturn(user)
+
+        // When & Then
+        assertThrows<IllegalArgumentException> {
+            reminderService.create("u1", ReminderCreateRequest(LocalDate.of(2026, 9, 12), "오전 반차", null))
         }
         verify(reminderRepository, never()).save(any<DateReminder>())
     }


### PR DESCRIPTION
미인증 사용자의 알림 등록을 차단(ROLE_VERIFIED 필요). 더존 이메일 인증을 해야 알림 기능 사용 가능.