### PR TITLE
🐛 Fix: 채팅/친구 API CORS preflight 차단 수정

### DIFF
--- a/src/main/kotlin/com/connect/service/common/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/connect/service/common/security/SecurityConfig.kt
@@ -45,6 +45,10 @@ class SecurityConfig(
                     .requestMatchers("/api/boards/**").permitAll() // 게시판 API 경로
                     // 비밀번호 찾기/더존 인증/날짜 알림 등 계정 관련 경로 허용 (CORS preflight 통과 + 컨트롤러에서 자체 인증 검사)
                     .requestMatchers("/api/account/**").permitAll()
+                    // 채팅/친구/웹소켓 경로 허용 (웹에서 CORS preflight 통과 - JWT 는 필터에서 처리)
+                    .requestMatchers("/api/chat/**").permitAll()
+                    .requestMatchers("/api/friends/**").permitAll()
+                    .requestMatchers("/ws-chat/**").permitAll()
                     .anyRequest().authenticated() // 그 외 모든 요청은 인증 필요
             }
             .headers { headers ->


### PR DESCRIPTION
웹에서 /api/chat/**, /api/friends/** 호출 시 OPTIONS preflight 가 Spring Security 에 막혀 '채팅 목록을 가져오지 못했습니다.' 발생하던 문제 수정. 해당 경로 + /ws-chat/** permitAll 추가 (JWT 는 필터에서 처리). /api/account 와 동일 원인.