### PR TITLE
✨ Feat: 프로필 사진 업로드 (Cloudflare R2)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,6 +39,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("io.github.microutils:kotlin-logging:3.0.5")
     implementation("org.springframework.boot:spring-boot-starter-mail")
+    implementation("software.amazon.awssdk:s3:2.25.60") // Cloudflare R2 (S3 호환) 프로필 이미지 업로드
 
     implementation("com.querydsl:querydsl-jpa:5.0.0:jakarta")
     implementation("com.querydsl:querydsl-core:5.0.0")

--- a/src/main/kotlin/com/connect/service/user/controller/AccountController.kt
+++ b/src/main/kotlin/com/connect/service/user/controller/AccountController.kt
@@ -4,10 +4,12 @@ import com.connect.service.common.ApiResponse
 import com.connect.service.user.domain.UserRole
 import com.connect.service.user.dto.EmailRequest
 import com.connect.service.user.dto.ResetPasswordRequest
+import com.connect.service.user.dto.ProfileImageRequest
 import com.connect.service.user.dto.UpdateNameRequest
 import com.connect.service.user.dto.UserInfoResponse
 import com.connect.service.user.dto.VerificationRequest
 import com.connect.service.user.service.AccountService
+import com.connect.service.user.service.ProfileImageService
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.Authentication
@@ -17,7 +19,8 @@ import org.springframework.web.bind.annotation.*
 @RequestMapping("/api/account")
 @CrossOrigin
 class AccountController (
-    private val accountService: AccountService
+    private val accountService: AccountService,
+    private val profileImageService: ProfileImageService
 ){
     /**
      * 비밀번호 찾기: 인증번호 발송 요청
@@ -144,6 +147,38 @@ class AccountController (
             ResponseEntity.ok(ApiResponse.success("더존 이메일 인증이 완료되었습니다.", info))
         } catch (e: IllegalArgumentException) {
             ResponseEntity.badRequest().body(ApiResponse.error(e.message ?: "잘못된 요청입니다."))
+        }
+    }
+
+    /**
+     * 프로필 사진 업로드 (R2 저장 후 URL 을 profileUrl 에 저장)
+     * POST /api/account/me/profile-image
+     */
+    @PostMapping("/me/profile-image")
+    fun updateProfileImage(
+        @RequestBody request: ProfileImageRequest,
+        authentication: Authentication?
+    ): ResponseEntity<ApiResponse<UserInfoResponse>> {
+        if (authentication == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(ApiResponse.error("로그인이 필요합니다."))
+        }
+        return try {
+            val updated = profileImageService.updateProfileImage(
+                authentication.name, request.imageBase64, request.contentType
+            )
+            val info = UserInfoResponse(
+                updated.userId, updated.email, updated.name, updated.profileUrl,
+                updated.roles.contains(UserRole.ROLE_VERIFIED)
+            )
+            ResponseEntity.ok(ApiResponse.success("프로필 사진이 변경되었습니다.", info))
+        } catch (e: IllegalArgumentException) {
+            ResponseEntity.badRequest().body(ApiResponse.error(e.message ?: "잘못된 요청입니다."))
+        } catch (e: IllegalStateException) {
+            // R2 미설정 등
+            ResponseEntity.internalServerError().body(ApiResponse.error(e.message ?: "이미지 업로드 설정 오류입니다."))
+        } catch (e: Exception) {
+            ResponseEntity.internalServerError().body(ApiResponse.error("프로필 사진 업로드에 실패했습니다."))
         }
     }
 }

--- a/src/main/kotlin/com/connect/service/user/domain/Users.kt
+++ b/src/main/kotlin/com/connect/service/user/domain/Users.kt
@@ -24,7 +24,7 @@ data class Users(
     @Column(name = "password", nullable = false)
     var rawPassword: String, // 비밀번호 (암호화하여 저장)
 
-    val profileUrl: String? = null,
+    var profileUrl: String? = null,
 
     // 계정의 권한 목록
     @ElementCollection(fetch = FetchType.EAGER) // 즉시 로딩

--- a/src/main/kotlin/com/connect/service/user/dto/ProfileImageRequest.kt
+++ b/src/main/kotlin/com/connect/service/user/dto/ProfileImageRequest.kt
@@ -1,0 +1,7 @@
+package com.connect.service.user.dto
+
+// 프로필 이미지 업로드 요청 (base64 이미지 데이터). data URI 접두사(data:image/...;base64,)는 있어도/없어도 처리됨.
+data class ProfileImageRequest(
+    val imageBase64: String,
+    val contentType: String? = null
+)

--- a/src/main/kotlin/com/connect/service/user/service/ProfileImageService.kt
+++ b/src/main/kotlin/com/connect/service/user/service/ProfileImageService.kt
@@ -1,0 +1,78 @@
+package com.connect.service.user.service
+
+import com.connect.service.user.domain.Users
+import com.connect.service.user.repository.UserRepository
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
+import software.amazon.awssdk.core.sync.RequestBody
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.PutObjectRequest
+import java.net.URI
+import java.util.Base64
+
+// 프로필 이미지를 Cloudflare R2(S3 호환)에 업로드하고 공개 URL을 Users.profileUrl 에 저장한다.
+@Service
+class ProfileImageService(
+    private val userRepository: UserRepository,
+    @Value("\${r2.endpoint:}") private val endpoint: String,
+    @Value("\${r2.access-key:}") private val accessKey: String,
+    @Value("\${r2.secret-key:}") private val secretKey: String,
+    @Value("\${r2.bucket:}") private val bucket: String,
+    @Value("\${r2.public-base-url:}") private val publicBaseUrl: String
+) {
+    // 설정이 채워졌을 때만 클라이언트 생성 (미설정 시 앱 기동에는 영향 없이, 업로드 시점에만 에러)
+    private val s3Client: S3Client by lazy {
+        check(endpoint.isNotBlank() && accessKey.isNotBlank() && secretKey.isNotBlank() && bucket.isNotBlank()) {
+            "이미지 저장소(R2) 설정이 필요합니다."
+        }
+        S3Client.builder()
+            .endpointOverride(URI.create(endpoint))
+            .region(Region.of("auto")) // R2 는 region "auto"
+            .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey)))
+            .build()
+    }
+
+    @Transactional
+    fun updateProfileImage(userId: String, imageBase64: String, contentType: String?): Users {
+        val user = userRepository.findByUserId(userId)
+            ?: throw IllegalArgumentException("사용자를 찾을 수 없습니다.")
+
+        val bytes = try {
+            Base64.getDecoder().decode(stripDataUri(imageBase64).trim())
+        } catch (e: IllegalArgumentException) {
+            throw IllegalArgumentException("이미지 데이터가 올바르지 않습니다.")
+        }
+        if (bytes.isEmpty()) {
+            throw IllegalArgumentException("이미지 데이터가 비어 있습니다.")
+        }
+
+        val ext = extensionOf(contentType)
+        val key = "profile/${userId}_${System.currentTimeMillis()}.$ext"
+
+        s3Client.putObject(
+            PutObjectRequest.builder()
+                .bucket(bucket)
+                .key(key)
+                .contentType(contentType ?: "image/jpeg")
+                .build(),
+            RequestBody.fromBytes(bytes)
+        )
+
+        user.profileUrl = "${publicBaseUrl.trimEnd('/')}/$key"
+        return userRepository.save(user)
+    }
+
+    // data URI(data:image/png;base64,xxxx) 형태면 콤마 뒤 실제 base64만 추출
+    private fun stripDataUri(s: String): String = if (s.contains(",")) s.substringAfter(",") else s
+
+    fun extensionOf(contentType: String?): String = when (contentType?.lowercase()) {
+        "image/png" -> "png"
+        "image/gif" -> "gif"
+        "image/webp" -> "webp"
+        else -> "jpg"
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -28,6 +28,13 @@ spring.security.oauth2.client.provider.kakao.user-name-attribute=id
 # 카카오 로그인 완료 후 토큰을 돌려보낼 수 있는 앱 리다이렉트 URI 화이트리스트 (오픈 리다이렉트 방지)
 app.oauth2.allowed-redirect-uris=${APP_OAUTH2_ALLOWED_REDIRECT_URIS:exp://,exps://,connect://,http://localhost,http://127.0.0.1}
 
+# Cloudflare R2 (프로필 이미지 저장). 실제 값은 application-dev.properties 또는 환경변수로 주입.
+r2.endpoint=${R2_ENDPOINT:}
+r2.access-key=${R2_ACCESS_KEY:}
+r2.secret-key=${R2_SECRET_KEY:}
+r2.bucket=${R2_BUCKET:}
+r2.public-base-url=${R2_PUBLIC_BASE_URL:}
+
 spring.mail.host=smtp.gmail.com
 spring.mail.port=587
 spring.mail.username=kingle1024@gmail.com

--- a/src/test/kotlin/com/connect/service/user/ProfileImageServiceTest.kt
+++ b/src/test/kotlin/com/connect/service/user/ProfileImageServiceTest.kt
@@ -1,0 +1,32 @@
+package com.connect.service.user
+
+import com.connect.service.user.repository.UserRepository
+import com.connect.service.user.service.ProfileImageService
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import kotlin.test.assertEquals
+
+class ProfileImageServiceTest {
+
+    // 설정값은 비워도 extensionOf 는 순수 함수라 동작 (s3 클라이언트는 lazy 라 생성 안 됨)
+    private val service = ProfileImageService(
+        userRepository = mock<UserRepository>(),
+        endpoint = "",
+        accessKey = "",
+        secretKey = "",
+        bucket = "",
+        publicBaseUrl = ""
+    )
+
+    @Test
+    @DisplayName("contentType 에 따라 파일 확장자를 매핑한다")
+    fun `확장자_매핑`() {
+        assertEquals("png", service.extensionOf("image/png"))
+        assertEquals("gif", service.extensionOf("image/gif"))
+        assertEquals("webp", service.extensionOf("image/webp"))
+        assertEquals("jpg", service.extensionOf("image/jpeg"))
+        assertEquals("jpg", service.extensionOf(null))
+        assertEquals("jpg", service.extensionOf("application/octet-stream"))
+    }
+}


### PR DESCRIPTION
프로필 사진 업로드 백엔드. POST /api/account/me/profile-image 로 base64 이미지를 받아 R2(S3 호환)에 업로드하고 공개 URL 을 profileUrl 에 저장. R2 자격증명은 r2.* 설정(application-dev.properties/환경변수). 미설정 시 업로드 시점에만 에러.