### PR TITLE
프로필 사진 삭제 시 R2 객체까지 삭제

### DIFF
--- a/src/main/kotlin/com/connect/service/user/service/ProfileImageService.kt
+++ b/src/main/kotlin/com/connect/service/user/service/ProfileImageService.kt
@@ -2,6 +2,7 @@ package com.connect.service.user.service
 
 import com.connect.service.user.domain.Users
 import com.connect.service.user.repository.UserRepository
+import mu.KotlinLogging
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -11,6 +12,7 @@ import software.amazon.awssdk.core.sync.RequestBody
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.S3Configuration
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest
 import software.amazon.awssdk.services.s3.model.PutObjectRequest
 import java.net.URI
 import java.util.Base64
@@ -25,6 +27,8 @@ class ProfileImageService(
     @Value("\${r2.bucket:}") private val bucket: String,
     @Value("\${r2.public-base-url:}") private val publicBaseUrl: String
 ) {
+    private val log = KotlinLogging.logger {}
+
     // 설정이 채워졌을 때만 클라이언트 생성 (미설정 시 앱 기동에는 영향 없이, 업로드 시점에만 에러)
     private val s3Client: S3Client by lazy {
         check(endpoint.isNotBlank() && accessKey.isNotBlank() && secretKey.isNotBlank() && bucket.isNotBlank()) {
@@ -69,11 +73,32 @@ class ProfileImageService(
         return userRepository.save(user)
     }
 
-    // 프로필 사진 삭제 (기본 이미지로 되돌리기). profileUrl 을 비워 기본 아이콘이 보이게 한다.
+    // 프로필 사진 삭제 (기본 이미지로 되돌리기). R2 객체를 삭제하고 profileUrl 을 비워 기본 아이콘이 보이게 한다.
     @Transactional
     fun clearProfileImage(userId: String): Users {
         val user = userRepository.findByUserId(userId)
             ?: throw IllegalArgumentException("사용자를 찾을 수 없습니다.")
+
+        // R2 실제 객체도 삭제(best-effort). 실패해도 참조 해제는 진행해 기본 이미지로 되돌린다.
+        val currentUrl = user.profileUrl
+        if (!currentUrl.isNullOrBlank() && publicBaseUrl.isNotBlank()) {
+            val prefix = "${publicBaseUrl.trimEnd('/')}/"
+            if (currentUrl.startsWith(prefix)) {
+                val key = currentUrl.removePrefix(prefix)
+                try {
+                    s3Client.deleteObject(
+                        DeleteObjectRequest.builder()
+                            .bucket(bucket)
+                            .key(key)
+                            .build()
+                    )
+                } catch (e: Exception) {
+                    // R2 미설정/네트워크 오류 등은 무시하고 참조 해제만 진행
+                    log.warn("R2 프로필 객체 삭제 실패(무시): key=$key, ${e.message}")
+                }
+            }
+        }
+
         user.profileUrl = null
         return userRepository.save(user)
     }

--- a/src/test/kotlin/com/connect/service/user/ProfileImageServiceTest.kt
+++ b/src/test/kotlin/com/connect/service/user/ProfileImageServiceTest.kt
@@ -1,17 +1,23 @@
 package com.connect.service.user
 
+import com.connect.service.user.domain.Users
 import com.connect.service.user.repository.UserRepository
-import com.connect.service.user.service.ProfileImageService
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import com.connect.service.user.service.ProfileImageService
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 class ProfileImageServiceTest {
 
+    private val userRepository = mock<UserRepository>()
+
     // 설정값은 비워도 extensionOf 는 순수 함수라 동작 (s3 클라이언트는 lazy 라 생성 안 됨)
     private val service = ProfileImageService(
-        userRepository = mock<UserRepository>(),
+        userRepository = userRepository,
         endpoint = "",
         accessKey = "",
         secretKey = "",
@@ -28,5 +34,24 @@ class ProfileImageServiceTest {
         assertEquals("jpg", service.extensionOf("image/jpeg"))
         assertEquals("jpg", service.extensionOf(null))
         assertEquals("jpg", service.extensionOf("application/octet-stream"))
+    }
+
+    @Test
+    @DisplayName("프로필 사진 삭제 시 profileUrl 을 null 로 비운다 (R2 미설정이어도 참조 해제는 성공)")
+    fun `삭제시_profileUrl_을_null_로_비운다`() {
+        val user = Users(
+            userId = "u1",
+            email = "u1@douzone.com",
+            name = "테스터",
+            rawPassword = "encoded",
+            profileUrl = "https://pub-xxxx.r2.dev/profile/u1_123.jpg"
+        )
+        whenever(userRepository.findByUserId("u1")).thenReturn(user)
+        whenever(userRepository.save(any<Users>())).thenAnswer { it.arguments[0] as Users }
+
+        val result = service.clearProfileImage("u1")
+
+        // publicBaseUrl 이 비어 있어 R2 삭제는 건너뛰고, 참조만 해제된다
+        assertNull(result.profileUrl)
     }
 }


### PR DESCRIPTION
프로필 사진 삭제 시 R2 실제 객체도 best-effort 로 삭제하도록 보강.

- profileUrl 에서 key 추출 후 DeleteObjectRequest 호출
- 삭제 실패(미설정/네트워크)에도 참조 해제는 진행 → 기본 이미지로 복귀
- 테스트 추가(R2 미설정 시 profileUrl null 검증)